### PR TITLE
plan() method to return Route, Trip, Agency gtfsId

### DIFF
--- a/src/main/java/org/opentripplanner/client/model/Agency.java
+++ b/src/main/java/org/opentripplanner/client/model/Agency.java
@@ -1,3 +1,5 @@
 package org.opentripplanner.client.model;
 
-public record Agency(String name) {}
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record Agency(@JsonProperty("gtfsId") String id, String name) {}

--- a/src/main/java/org/opentripplanner/client/model/Leg.java
+++ b/src/main/java/org/opentripplanner/client/model/Leg.java
@@ -14,6 +14,7 @@ public record Leg(
     Duration duration,
     double distance,
     Route route,
+    Trip trip,
     List<FareProductUse> fareProducts,
     OptionalDouble accessibilityScore) {
 

--- a/src/main/java/org/opentripplanner/client/model/Route.java
+++ b/src/main/java/org/opentripplanner/client/model/Route.java
@@ -1,9 +1,14 @@
 package org.opentripplanner.client.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Optional;
 
 public record Route(
-    Optional<String> shortName, Optional<String> longName, TransitMode mode, Agency agency) {
+    @JsonProperty("gtfsId") String id,
+    Optional<String> shortName,
+    Optional<String> longName,
+    TransitMode mode,
+    Agency agency) {
 
   /**
    * Either the short name (if it has one) or the long name.

--- a/src/main/java/org/opentripplanner/client/model/Trip.java
+++ b/src/main/java/org/opentripplanner/client/model/Trip.java
@@ -1,0 +1,9 @@
+package org.opentripplanner.client.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Optional;
+
+public record Trip(
+    @JsonProperty("gtfsId") String id,
+    Optional<String> tripShortName,
+    Optional<String> tripHeadsign) {}

--- a/src/main/resources/queries/plan.graphql
+++ b/src/main/resources/queries/plan.graphql
@@ -36,11 +36,16 @@ query {
                 }
                 mode
                 route {
+                    gtfsId
                     shortName
                     longName
                     agency {
+                        gtfsId
                         name
                     }
+                }
+                trip {
+                    gtfsId tripShortName tripHeadsign
                 }
                 duration
                 distance


### PR DESCRIPTION
We use feed gtfsId to have exact references from GTFS feeds in OTP to the inventory system. Making the client to return these from the OTP.