### PR TITLE
Add response properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,16 @@
       <artifactId>guava</artifactId>
       <version>33.2.1-jre</version>
     </dependency>
+    <dependency>
+      <groupId>io.leonard</groupId>
+      <artifactId>google-polyline-codec</artifactId>
+      <version>0.0.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.locationtech.jts</groupId>
+      <artifactId>jts-core</artifactId>
+      <version>1.19.0</version>
+    </dependency>
 
     <!-- Test -->
     <dependency>

--- a/src/main/java/org/opentripplanner/client/model/FormFactor.java
+++ b/src/main/java/org/opentripplanner/client/model/FormFactor.java
@@ -1,0 +1,12 @@
+package org.opentripplanner.client.model;
+
+public enum FormFactor {
+  BICYCLE,
+  CARGO_BICYCLE,
+  CAR,
+  MOPED,
+  SCOOTER,
+  SCOOTER_STANDING,
+  SCOOTER_SEATED,
+  OTHER
+}

--- a/src/main/java/org/opentripplanner/client/model/IntermediatePlace.java
+++ b/src/main/java/org/opentripplanner/client/model/IntermediatePlace.java
@@ -1,0 +1,6 @@
+package org.opentripplanner.client.model;
+
+import java.time.OffsetDateTime;
+
+public record IntermediatePlace(
+    String name, OffsetDateTime departureTime, OffsetDateTime arrivalTime, Stop stop) {}

--- a/src/main/java/org/opentripplanner/client/model/Leg.java
+++ b/src/main/java/org/opentripplanner/client/model/Leg.java
@@ -16,7 +16,8 @@ public record Leg(
     Route route,
     Trip trip,
     List<FareProductUse> fareProducts,
-    OptionalDouble accessibilityScore) {
+    OptionalDouble accessibilityScore,
+    Agency agency) {
 
   /** Is this leg using public transport? */
   public boolean isTransit() {

--- a/src/main/java/org/opentripplanner/client/model/Leg.java
+++ b/src/main/java/org/opentripplanner/client/model/Leg.java
@@ -1,8 +1,10 @@
 package org.opentripplanner.client.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.OptionalDouble;
 
 public record Leg(
@@ -13,13 +15,15 @@ public record Leg(
     LegMode mode,
     Duration duration,
     double distance,
+    Optional<String> headsign,
     Route route,
     Trip trip,
     List<FareProductUse> fareProducts,
     OptionalDouble accessibilityScore,
     Agency agency,
-    LegGeometry legGeometry
-    ) {
+    LegGeometry legGeometry,
+    @JsonProperty("rentedBike") boolean rentedVehicle,
+    Optional<List<IntermediatePlace>> intermediatePlaces) {
 
   /** Is this leg using public transport? */
   public boolean isTransit() {

--- a/src/main/java/org/opentripplanner/client/model/Leg.java
+++ b/src/main/java/org/opentripplanner/client/model/Leg.java
@@ -17,7 +17,9 @@ public record Leg(
     Trip trip,
     List<FareProductUse> fareProducts,
     OptionalDouble accessibilityScore,
-    Agency agency) {
+    Agency agency,
+    LegGeometry legGeometry
+    ) {
 
   /** Is this leg using public transport? */
   public boolean isTransit() {

--- a/src/main/java/org/opentripplanner/client/model/LegGeometry.java
+++ b/src/main/java/org/opentripplanner/client/model/LegGeometry.java
@@ -1,0 +1,3 @@
+package org.opentripplanner.client.model;
+
+public record LegGeometry(String points) {}

--- a/src/main/java/org/opentripplanner/client/model/LegGeometry.java
+++ b/src/main/java/org/opentripplanner/client/model/LegGeometry.java
@@ -1,3 +1,39 @@
 package org.opentripplanner.client.model;
 
-public record LegGeometry(String points) {}
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.leonard.PolylineUtils;
+import io.leonard.Position;
+import java.util.List;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.PrecisionModel;
+
+public record LegGeometry(@JsonProperty("points") String pathString) {
+
+  private static final int DEFAULT_SRID = 4326;
+
+  private List<Position> toListOPositions() {
+    return PolylineUtils.decode(pathString, 5);
+  }
+
+  /**
+   * uses default SRID as defined in <a
+   * href="https://gtfs.org/schedule/reference/#field-types">GTFSdoc </a> to create a JTS Linestring
+   */
+  public LineString toLinestring() {
+    return toLinestring(DEFAULT_SRID);
+  }
+
+  /** create a JTS Linestring by a passed SRID */
+  public LineString toLinestring(int SRID) {
+    Coordinate[] coordinates =
+        toListOPositions().stream()
+            .map(position -> new Coordinate(position.getLongitude(), position.getLatitude()))
+            .toArray(Coordinate[]::new);
+
+    GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), SRID);
+
+    return (geometryFactory.createLineString(coordinates));
+  }
+}

--- a/src/main/java/org/opentripplanner/client/model/ParentStation.java
+++ b/src/main/java/org/opentripplanner/client/model/ParentStation.java
@@ -1,0 +1,5 @@
+package org.opentripplanner.client.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record ParentStation(@JsonProperty("gtfsId") String id) {}

--- a/src/main/java/org/opentripplanner/client/model/ParkingCapacity.java
+++ b/src/main/java/org/opentripplanner/client/model/ParkingCapacity.java
@@ -1,0 +1,5 @@
+package org.opentripplanner.client.model;
+
+import java.util.Optional;
+
+public record ParkingCapacity(Optional<Integer> bicycleSpaces, Optional<Integer> carSpaces) {}

--- a/src/main/java/org/opentripplanner/client/model/Place.java
+++ b/src/main/java/org/opentripplanner/client/model/Place.java
@@ -2,4 +2,11 @@ package org.opentripplanner.client.model;
 
 import java.util.Optional;
 
-public record Place(String name, Optional<Stop> stop) {}
+public record Place(
+    String name,
+    float lon,
+    float lat,
+    Optional<Stop> stop,
+    Optional<VehicleRentalStation> vehicleRentalStation,
+    Optional<RentalVehicle> rentalVehicle,
+    Optional<VehicleParking> vehicleParking) {}

--- a/src/main/java/org/opentripplanner/client/model/PropulsionType.java
+++ b/src/main/java/org/opentripplanner/client/model/PropulsionType.java
@@ -1,0 +1,12 @@
+package org.opentripplanner.client.model;
+
+public enum PropulsionType {
+  HUMAN,
+  ELECTRIC_ASSIST,
+  ELECTRIC,
+  COMBUSTION,
+  COMBUSTION_DIESEL,
+  HYBRID,
+  PLUG_IN_HYBRID,
+  HYDROGEN_FUEL_CELL
+}

--- a/src/main/java/org/opentripplanner/client/model/RentalVehicle.java
+++ b/src/main/java/org/opentripplanner/client/model/RentalVehicle.java
@@ -1,0 +1,10 @@
+package org.opentripplanner.client.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Optional;
+
+public record RentalVehicle(
+    @JsonProperty("vehicleId") String id,
+    Optional<String> name,
+    String network,
+    Optional<RentalVehicleType> vehicleType) {}

--- a/src/main/java/org/opentripplanner/client/model/RentalVehicleType.java
+++ b/src/main/java/org/opentripplanner/client/model/RentalVehicleType.java
@@ -1,0 +1,3 @@
+package org.opentripplanner.client.model;
+
+public record RentalVehicleType(FormFactor formFactor, PropulsionType propulsionType) {}

--- a/src/main/java/org/opentripplanner/client/model/Route.java
+++ b/src/main/java/org/opentripplanner/client/model/Route.java
@@ -7,6 +7,7 @@ public record Route(
     @JsonProperty("gtfsId") String id,
     Optional<String> shortName,
     Optional<String> longName,
+    @JsonProperty("type") int modeCode,
     TransitMode mode,
     Agency agency) {
 

--- a/src/main/java/org/opentripplanner/client/model/Stop.java
+++ b/src/main/java/org/opentripplanner/client/model/Stop.java
@@ -4,7 +4,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 import java.util.Optional;
 
-public record Stop(String name, @JsonProperty("gtfsId") String id, Optional<String> code) {
+public record Stop(
+    String name,
+    @JsonProperty("gtfsId") String id,
+    Optional<String> code,
+    Optional<String> zoneId,
+    ParentStation parentStation) {
   public Stop {
     Objects.requireNonNull(name);
     Objects.requireNonNull(id);

--- a/src/main/java/org/opentripplanner/client/model/VehicleParking.java
+++ b/src/main/java/org/opentripplanner/client/model/VehicleParking.java
@@ -1,0 +1,7 @@
+package org.opentripplanner.client.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Optional;
+
+public record VehicleParking(
+    @JsonProperty("vehicleParkingId") String id, String name, Optional<ParkingCapacity> capacity) {}

--- a/src/main/java/org/opentripplanner/client/model/VehicleRentalStation.java
+++ b/src/main/java/org/opentripplanner/client/model/VehicleRentalStation.java
@@ -1,3 +1,6 @@
 package org.opentripplanner.client.model;
 
-public record VehicleRentalStation(String name, float lat, float lon) {}
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record VehicleRentalStation(
+    @JsonProperty("stationId") String id, String name, float lat, float lon, String network) {}

--- a/src/main/resources/queries/plan.graphql
+++ b/src/main/resources/queries/plan.graphql
@@ -35,6 +35,9 @@ query {
                     }
                 }
                 mode
+                legGeometry {
+                    points
+                }
                 route {
                     gtfsId
                     shortName

--- a/src/main/resources/queries/plan.graphql
+++ b/src/main/resources/queries/plan.graphql
@@ -81,6 +81,10 @@ query {
                     }
                 }
                 accessibilityScore
+                agency {
+                    gtfsId,
+                    name
+                }
             }
         }
     }

--- a/src/main/resources/queries/plan.graphql
+++ b/src/main/resources/queries/plan.graphql
@@ -90,6 +90,7 @@ query {
                     }
                 }
                 mode
+                headsign
                 legGeometry {
                     points
                 }
@@ -109,10 +110,20 @@ query {
                 }
                 duration
                 distance
+                rentedBike
                 intermediatePlaces {
                     name
                     departureTime
                     arrivalTime
+                    stop {
+                        gtfsId
+                        name
+                        code
+                        zoneId
+                        parentStation {
+                            gtfsId
+                        }
+                    }
                 }
                 fareProducts {
                     id

--- a/src/main/resources/queries/plan.graphql
+++ b/src/main/resources/queries/plan.graphql
@@ -98,6 +98,7 @@ query {
                     gtfsId
                     shortName
                     longName
+                    type
                     agency {
                         gtfsId
                         name

--- a/src/main/resources/queries/plan.graphql
+++ b/src/main/resources/queries/plan.graphql
@@ -20,18 +20,73 @@ query {
                 endTime
                 from {
                     name
+                    lon
+                    lat
                     stop {
                         gtfsId
                         name
                         code
+                        zoneId
+                        parentStation {
+                            gtfsId
+                        }
+                    }
+                    vehicleRentalStation {
+                        stationId
+                        name
+                        network
+                    }
+                    rentalVehicle {
+                        vehicleId
+                        name
+                        network
+                        vehicleType {
+                            formFactor
+                            propulsionType
+                        }
+                    }
+                    vehicleParking {
+                        vehicleParkingId
+                        name
+                        capacity {
+                            bicycleSpaces
+                            carSpaces
+                        }
                     }
                 }
                 to {
                     name
+                    lon
+                    lat
                     stop {
                         gtfsId
                         name
                         code
+                        zoneId
+                        parentStation {
+                            gtfsId
+                        }
+                    }
+                    vehicleRentalStation {
+                        stationId
+                        name
+                        network
+                    }
+                    rentalVehicle {
+                        vehicleId
+                        name
+                        network
+                        vehicleType {
+                            formFactor
+                        }
+                    }
+                    vehicleParking {
+                        vehicleParkingId
+                        name
+                        capacity {
+                            bicycleSpaces
+                            carSpaces
+                        }
                     }
                 }
                 mode

--- a/src/main/resources/queries/routes.graphql
+++ b/src/main/resources/queries/routes.graphql
@@ -3,6 +3,7 @@ query {
         longName
         shortName
         mode
+        type
         agency {
             gtfsId
             name

--- a/src/main/resources/queries/stop.graphql
+++ b/src/main/resources/queries/stop.graphql
@@ -3,5 +3,9 @@ query {
         name
         gtfsId
         code
+        zoneId
+        parentStation {
+            gtfsId
+        }
     }
 }

--- a/src/main/resources/queries/vehicleRentalStations.graphql
+++ b/src/main/resources/queries/vehicleRentalStations.graphql
@@ -1,8 +1,10 @@
 query {
     vehicleRentalStations{
+        stationId
         name
         lat
         lon
+        network
         realtime
         vehiclesAvailable
     }


### PR DESCRIPTION
## Further Plan response properties

## context
We want to use OTP Java Client, but we need some more properties in the response in our use case.

For the leg, we need the agency, geometry information, intermediate places, and the head sign
For the place, we need more properties e.g. to show information about rental stations, and parking spots.
For the route, we need the more specific mode code

## description
added properties:
- agency, legGeometry, intermediatePlaces, headsign  to the leg
- vertexType, vehicleRentalStation, rentalVehicle, vehicleParking to the place
- type(mode code) to the route
