### PR TITLE
JTS geometries in Place

### DIFF
--- a/src/main/java/org/opentripplanner/client/model/Place.java
+++ b/src/main/java/org/opentripplanner/client/model/Place.java
@@ -1,6 +1,10 @@
 package org.opentripplanner.client.model;
 
 import java.util.Optional;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
 
 public record Place(
     String name,
@@ -9,4 +13,26 @@ public record Place(
     Optional<Stop> stop,
     Optional<VehicleRentalStation> vehicleRentalStation,
     Optional<RentalVehicle> rentalVehicle,
-    Optional<VehicleParking> vehicleParking) {}
+    Optional<VehicleParking> vehicleParking) {
+
+  private static final int DEFAULT_SRID = 4326;
+
+  /** create a JTS Geometry */
+  public Coordinate coordinate() {
+    return new Coordinate(lon, lat);
+  }
+
+  /**
+   * Return the geometry as JTF Point which defaults to SRID as defined in <a
+   * href="https://gtfs.org/schedule/reference/#field-types">GTFSdoc </a>.
+   */
+  public Point point() {
+    return point(DEFAULT_SRID);
+  }
+
+  /** creates a JTS Point by a passed SRID */
+  public Point point(int SRID) {
+    GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), SRID);
+    return geometryFactory.createPoint(coordinate());
+  }
+}

--- a/src/test/java/org/opentripplanner/IntegrationTest.java
+++ b/src/test/java/org/opentripplanner/IntegrationTest.java
@@ -72,7 +72,10 @@ public class IntegrationTest {
     assertNotNull(transitLeg.to().point());
     assertNotNull(transitLeg.from().stop().get().id());
     assertTrue(transitLeg.trip().headsign().isPresent());
-
+    assertNotNull(transitLeg.agency());
+    assertNotNull(transitLeg.intermediatePlaces().get().get(0).name());
+    assertNotNull(transitLeg.intermediatePlaces().get().get(0).departureTime());
+    assertNotNull(transitLeg.intermediatePlaces().get().get(0).arrivalTime());
     assertNotNull(transitLeg.geometry().toGoogleEncoding());
     assertNotNull(transitLeg.geometry().toLinestring());
 

--- a/src/test/java/org/opentripplanner/IntegrationTest.java
+++ b/src/test/java/org/opentripplanner/IntegrationTest.java
@@ -65,7 +65,11 @@ public class IntegrationTest {
 
     var transitLeg = result.transitItineraries().get(0).transitLegs().get(0);
     assertFalse(transitLeg.from().stop().isEmpty());
+    assertNotNull(transitLeg.from().coordinate());
+    assertNotNull(transitLeg.from().point());
     assertFalse(transitLeg.to().stop().isEmpty());
+    assertNotNull(transitLeg.to().coordinate());
+    assertNotNull(transitLeg.to().point());
     assertNotNull(transitLeg.from().stop().get().id());
     assertTrue(transitLeg.trip().headsign().isPresent());
 


### PR DESCRIPTION
# JTS geometries in Place

## context
On the LegGeometry we added methods, to get JTS LineStrings. To be consistent, it's good to add such methods in places(JTS Point, Geometry).

## Description
- This PR adds methods to get coordinates or points as JTS models from a Place object.
- also added tests for transit legs properties, which do not depend on the JTS changes.

