### PR TITLE
Filter null price fare products

### DIFF
--- a/assertions/src/main/java/org/opentripplanner/assertions/ItineraryAssertions.java
+++ b/assertions/src/main/java/org/opentripplanner/assertions/ItineraryAssertions.java
@@ -78,6 +78,7 @@ public class ItineraryAssertions {
                 .filter(fp -> fp.product().medium().isPresent())
                 .filter(fp -> fp.product().riderCategory().get().id().equals(riderCategoryId))
                 .filter(fp -> fp.product().medium().get().id().equals(mediumId))
+                .filter(fp -> fp.product().price() != null)
                 .anyMatch(fp -> fp.product().price().amount().floatValue() == price));
     return this;
   }

--- a/assertions/src/test/java/org/opentripplanner/assertions/ItineraryAssertionsTest.java
+++ b/assertions/src/test/java/org/opentripplanner/assertions/ItineraryAssertionsTest.java
@@ -131,8 +131,8 @@ class ItineraryAssertionsTest {
 
   @Test
   void withFarePriceHandlesPositiveAndNegativeMatches() {
-    List<FareProductUse> fares = List.of(fare("orca:regular", "orca:cash"),
-            fare(2.75f, "orca:regular", "orca:cash"));
+    List<FareProductUse> fares =
+        List.of(fare("orca:regular", "orca:cash"), fare(2.75f, "orca:regular", "orca:cash"));
     TripPlan plan =
         tripPlan(itinerary(transitLeg("E", "E Line", LegMode.BUS, Duration.ofMinutes(12), fares)));
 
@@ -239,14 +239,15 @@ class ItineraryAssertionsTest {
 
   private static FareProductUse fare(String riderCategoryId, String mediumId) {
     return new FareProductUse(
-            "fare-" + riderCategoryId + "-" + mediumId,
-            new FareProductUse.FareProduct(
-                    "product-" + riderCategoryId + "-" + mediumId,
-                    "Test fare",
-                    null,
-                    Optional.of(new FareProductUse.FareProduct.RiderCategory(riderCategoryId, "Rider")),
-                    Optional.of(new FareProductUse.FareProduct.FareMedium(mediumId, "Medium"))));
+        "fare-" + riderCategoryId + "-" + mediumId,
+        new FareProductUse.FareProduct(
+            "product-" + riderCategoryId + "-" + mediumId,
+            "Test fare",
+            null,
+            Optional.of(new FareProductUse.FareProduct.RiderCategory(riderCategoryId, "Rider")),
+            Optional.of(new FareProductUse.FareProduct.FareMedium(mediumId, "Medium"))));
   }
+
   private static FareProductUse fare(Float amount, String riderCategoryId, String mediumId) {
     return new FareProductUse(
         "fare-" + riderCategoryId + "-" + mediumId,

--- a/assertions/src/test/java/org/opentripplanner/assertions/ItineraryAssertionsTest.java
+++ b/assertions/src/test/java/org/opentripplanner/assertions/ItineraryAssertionsTest.java
@@ -131,7 +131,8 @@ class ItineraryAssertionsTest {
 
   @Test
   void withFarePriceHandlesPositiveAndNegativeMatches() {
-    List<FareProductUse> fares = List.of(fare(2.75f, "orca:regular", "orca:cash"));
+    List<FareProductUse> fares = List.of(fare("orca:regular", "orca:cash"),
+            fare(2.75f, "orca:regular", "orca:cash"));
     TripPlan plan =
         tripPlan(itinerary(transitLeg("E", "E Line", LegMode.BUS, Duration.ofMinutes(12), fares)));
 
@@ -236,7 +237,17 @@ class ItineraryAssertionsTest {
         name, 10.0f, 10.0f, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
   }
 
-  private static FareProductUse fare(float amount, String riderCategoryId, String mediumId) {
+  private static FareProductUse fare(String riderCategoryId, String mediumId) {
+    return new FareProductUse(
+            "fare-" + riderCategoryId + "-" + mediumId,
+            new FareProductUse.FareProduct(
+                    "product-" + riderCategoryId + "-" + mediumId,
+                    "Test fare",
+                    null,
+                    Optional.of(new FareProductUse.FareProduct.RiderCategory(riderCategoryId, "Rider")),
+                    Optional.of(new FareProductUse.FareProduct.FareMedium(mediumId, "Medium"))));
+  }
+  private static FareProductUse fare(Float amount, String riderCategoryId, String mediumId) {
     return new FareProductUse(
         "fare-" + riderCategoryId + "-" + mediumId,
         new FareProductUse.FareProduct(


### PR DESCRIPTION
Apparently we can now get fare products back from OTP with null price. It was causing crashes so with this change we filter out those fare products. 

Also added a test with a null price fare product. 